### PR TITLE
Add tip for adding nvcc to a working torch w/ conda

### DIFF
--- a/doc/python/installation.rst
+++ b/doc/python/installation.rst
@@ -149,6 +149,28 @@ First of all, make sure that you are using a C++ compiler which is compatible wi
 
 .. _`part.cache`:
 
+Adding nvcc to a working conda torch installation
+-------------------------------------------------
+A common starting point for users working with conda and torch is to have a working gpu accelerated installation of pytorch, without nvcc. In this situation, it is possible to add nvcc to PATH without installing anything globally or modifying your drivers.
+
+1. Find the version of CUDA that pytorch is using. With conda, this is often different from the system-wide CUDA version
+
+.. code-block:: python
+
+  import torch
+  torch.version.cuda
+
+2. Download a matching CUDA runfile installer from https://developer.nvidia.com/cuda-downloads
+
+3. Install the runfile using the --toolkit and --toolkitpath options.  This installs nvcc to a directory, without modifying your drivers or system configuration. Do not use sudo, to guarantee that this step doesn't modify your drivers. For example,
+
+.. code-block:: bash
+  sh cuda_10.0.130_410.48_linux --silent --override --toolkit --toolkitpath=/local/path/to/put/nvcc
+  
+4. Add /local/path/to/put/nvcc/bin to $PATH and /local/path/to/put/nvcc/lib64 to $LD_LIBRARY_PATH . You can either do this in .bashrc, or a script local to your pykeops project
+
+
+
 Cache directory
 ---------------
 


### PR DESCRIPTION
Hi! This is an approach that I found is reliably able to add pykeops to a working torch / conda installation, and which doesn't risk messing up the system-wide driver situation, especially on shared machines. Would you be interested in including it in the official documentation? Thanks for considering my pull request.